### PR TITLE
I've added the option to not resize an image upload

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -62,6 +62,7 @@ Configuration options (default values between parentheses):
 * @images_size@: Array of different file sizes required by your app. Each
   element is itself an array, like: @'folder_name' => array($width, $height, $crop)@.
   (You may define only width or height, and the image will scale appropriately).
+  Pass an empty array to simply copy the file without resizing.
 
 You can override the default configuration passing an array of options while
 including the component, like:

--- a/attachment.php
+++ b/attachment.php
@@ -102,10 +102,17 @@ class AttachmentComponent extends Object {
 		/* If it's image get image size and make thumbnail copies. */
 		if ($this->is_image($filetype)) {
 			$this->copy_or_log_error($data[$column_prefix]['tmp_name'], $tmpuploaddir, $filename);
-			/* Create each thumbnail_size */
-			foreach ($this->config['images_size'] as $dir => $opts) {
-				$this->thumbnail($tmpuploaddir.DS.$filename, $dir, $opts[0], $opts[1], $opts[2]);
-			}
+
+                        if(empty($this->config['images_size'])) {
+                            /* No thumbnails needed */
+                            $upload_dir = WWW_ROOT.'attachments'.DS.$this->config['files_dir'];
+                            $this->copy_or_log_error($tmpuploaddir.DS.$filename, $upload_dir, $filename);
+                        } else {
+                            /* Create each thumbnail_size */
+                            foreach ($this->config['images_size'] as $dir => $opts) {
+                                    $this->thumbnail($tmpuploaddir.DS.$filename, $dir, $opts[0], $opts[1], $opts[2]);
+                            }
+                        }
 			if ($this->config['rm_tmp_file'])
 				unlink($tmpuploaddir.DS.$filename);
 		} else {
@@ -165,11 +172,17 @@ class AttachmentComponent extends Object {
 		if (is_file(WWW_ROOT.'attachments'.DS.'tmp'.DS.$filename)) {
 			unlink(WWW_ROOT.'attachments'.DS.'tmp'.DS.$filename);
 		}
-		/* Thumbnail copies */
-		foreach ($this->config['images_size'] as $size => $opts) {
-			$photo = WWW_ROOT.'attachments'.DS.$this->config['files_dir'].DS.$size.DS.$filename;
+                /* Images */
+                if (empty($this->config['images_size'])) {
+			$photo = WWW_ROOT.'attachments'.DS.$this->config['files_dir'].DS.$filename;
 			if (is_file($photo)) unlink($photo);
-		}
+                } else {
+                    /* Thumbnail copies */
+                    foreach ($this->config['images_size'] as $size => $opts) {
+                            $photo = WWW_ROOT.'attachments'.DS.$this->config['files_dir'].DS.$size.DS.$filename;
+                            if (is_file($photo)) unlink($photo);
+                    }
+                }
 	}
 
 	/*


### PR DESCRIPTION
Hello! I tried out your very useful component and loved it, but then realized that there was no way to keep an uploaded image as is and not resize it. I added that option and made it so that you pass an empty array as images_size to accomplish this. I also modified the delete_files function to properly get rid of that file. I hope you like it!
